### PR TITLE
feat: Isolate creating a new httpx.AsyncClient ...

### DIFF
--- a/pytouchline_extended/__init__.py
+++ b/pytouchline_extended/__init__.py
@@ -1,10 +1,13 @@
-import httpx
-import cchardet as chardet
-import xml.etree.ElementTree as ET
 import asyncio
 import logging
+import xml.etree.ElementTree as ET
+
+import cchardet as chardet
+import httpx
 
 __author__ = 'brondum'
+
+from httpx import AsyncClient
 
 logger = logging.getLogger(__name__)
 
@@ -53,6 +56,9 @@ class PyTouchline(object):
 			Parameter(name="ownerKurzID", desc="Controller ID",
 					  type=Parameter.G))
 
+	def get_async_client(self) -> AsyncClient:
+		return httpx.AsyncClient(verify=False, timeout=self._timeout)
+
 	async def get_number_of_devices_async(self) -> int:
 		number_of_devices_items = []
 		number_of_devices_items.append("<i><n>totalNumberOfDevices</n></i>")
@@ -65,7 +71,7 @@ class PyTouchline(object):
 
 	def get_number_of_devices(self) -> int:
 		return asyncio.run(self.get_number_of_devices_async())
-	
+
 	async def get_hostname_async(self) -> str | None:
 		hostname_items = []
 		hostname_items.append("<i><n>hw.HostName</n></i>")
@@ -130,7 +136,7 @@ class PyTouchline(object):
 		return request
 
 	async def write_parameter_async(self, parameter, value):
-		async with httpx.AsyncClient(timeout=10.0) as client:
+		async with self.get_async_client() as client:
 			response = await client.request(
 				url=self._url +
 					self._write_path + "?" +
@@ -153,7 +159,7 @@ class PyTouchline(object):
 		logger.debug("Requesting URL: %s%s (timeout: %.1fs)", self._url, self._read_path, self._timeout)
 
 		try:
-			async with httpx.AsyncClient(timeout=self._timeout) as client:
+			async with self.get_async_client() as client:
 				response = await client.request(
 					url=self._url + self._read_path,
 					method="POST",

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-description-file = README.md
+description_file = README.md

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,10 @@
-import pytest
-from pytouchline_extended import PyTouchline, Parameter
-from unittest.mock import AsyncMock, patch, MagicMock
 import xml.etree.ElementTree as ET
+from ssl import VerifyMode
+from unittest.mock import AsyncMock, patch, MagicMock
+
+import pytest
+
+from pytouchline_extended import PyTouchline, Parameter
 
 
 def test_init():
@@ -375,3 +378,24 @@ async def test_request_and_receive_xml_network_error():
 
         with pytest.raises(Exception, match="Network error connecting to Touchline controller"):
             await touchline._request_and_receive_xml("<test/>")
+
+
+@pytest.mark.asyncio
+async def test_get_async_client():
+    """Test get_async_client returns a correctly configured httpx.AsyncClient"""
+    import httpx
+    timeout = 15.0
+    touchline = PyTouchline(id=0, url="http://192.168.1.254", timeout=timeout)
+
+    client = touchline.get_async_client()
+
+    assert isinstance(client, httpx.AsyncClient)
+    assert client.timeout.connect == timeout
+    assert client.timeout.read == timeout
+    assert client.timeout.write == timeout
+    assert client.timeout.pool == timeout
+    # verify=False in httpx is handled by the transport
+    assert client._transport._pool._ssl_context.check_hostname is False
+    assert client._transport._pool._ssl_context.verify_mode is VerifyMode.CERT_NONE
+
+    await client.aclose()


### PR DESCRIPTION
... so it's easy to override in a subclass with a different implementation.

And change the default implementation to disable TLS verification as Roth controllers do not support TLS anyway.

This fixes #52 